### PR TITLE
Move`equals` to VariableType

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ use ScrumWorks\PropertyReader\VariableType\ScalarVariableType;
 
 /** @var ArrayVariableType $hashmapType */
 $hashmapType = $propertyReader->readUnifiedVariableType($reflection->getProperty('hashmap'));
-assert($hashmapType->nullable === false);
-assert($hashmapType->keyType instanceofScalarVariableType);
-assert($hashmapType->keyType->type === ScalarVariableType::TYPE_STRING)
+assert($hashmapType->isNullable() === false);
+assert($hashmapType->getKeyType() instanceof ScalarVariableType);
+assert($hashmapType->getKeyType()->getType() === ScalarVariableType::TYPE_STRING);
 ```
 
 ## Testing

--- a/src/PropertyWriter.php
+++ b/src/PropertyWriter.php
@@ -21,39 +21,39 @@ final class PropertyWriter
             }
             return 'mixed';
         } elseif ($variableType instanceof ScalarVariableType) {
-            switch ($variableType->type) {
-                case ScalarVariableType::TYPE_INTEGER: return ($variableType->nullable ? '?' : '') . 'int';
-                case ScalarVariableType::TYPE_FLOAT: return ($variableType->nullable ? '?' : '') . 'float';
-                case ScalarVariableType::TYPE_BOOLEAN: return ($variableType->nullable ? '?' : '') . 'bool';
-                case ScalarVariableType::TYPE_STRING: return ($variableType->nullable ? '?' : '') . 'string';
+            switch ($variableType->getType()) {
+                case ScalarVariableType::TYPE_INTEGER: return ($variableType->isNullable() ? '?' : '') . 'int';
+                case ScalarVariableType::TYPE_FLOAT: return ($variableType->isNullable() ? '?' : '') . 'float';
+                case ScalarVariableType::TYPE_BOOLEAN: return ($variableType->isNullable() ? '?' : '') . 'bool';
+                case ScalarVariableType::TYPE_STRING: return ($variableType->isNullable() ? '?' : '') . 'string';
             }
         } elseif ($variableType instanceof ArrayVariableType) {
             if ($phpCompatible) {
                 return 'array';
             }
-            if ($variableType->keyType === null) {
-                if ($variableType->itemType instanceof MixedVariableType) {
-                    return ($variableType->nullable ? '?' : '') . 'array';
+            if ($variableType->getKeyType() === null) {
+                if ($variableType->getItemType() instanceof MixedVariableType) {
+                    return ($variableType->isNullable() ? '?' : '') . 'array';
                 }
-                return ($variableType->nullable ? '?' : '') . $this->variableTypeToString(
-                    $variableType->itemType
+                return ($variableType->isNullable() ? '?' : '') . $this->variableTypeToString(
+                    $variableType->getItemType()
                 ) . '[]';
             }
             return \sprintf(
                     '%sarray<%s, %s>',
-                    $variableType->nullable ? '?' : '',
-                    $this->variableTypeToString($variableType->keyType),
-                    $this->variableTypeToString($variableType->itemType)
+                    $variableType->isNullable() ? '?' : '',
+                    $this->variableTypeToString($variableType->getKeyType()),
+                    $this->variableTypeToString($variableType->getItemType())
                 );
         } elseif ($variableType instanceof ClassVariableType) {
-            return ($variableType->nullable ? '?' : '') . $variableType->class;
+            return ($variableType->isNullable() ? '?' : '') . $variableType->getClass();
         } elseif ($variableType instanceof UnionVariableType) {
             if ($phpCompatible) {
                 return '';
             }
-            return ($variableType->nullable ? '?' : '') . \implode('|', \array_map(
+            return ($variableType->isNullable() ? '?' : '') . \implode('|', \array_map(
                 fn (VariableTypeInterface $_) => $this->variableTypeToString($_, $phpCompatible),
-                $variableType->types
+                $variableType->getTypes()
             ));
         }
         return '';

--- a/src/VariableType/AbstractVariableType.php
+++ b/src/VariableType/AbstractVariableType.php
@@ -6,10 +6,6 @@ namespace ScrumWorks\PropertyReader\VariableType;
 
 use Nette\SmartObject;
 
-/**
- * @property-read string $typeName
- * @property-read bool $nullable
- */
 /*, Stringable - after PHp8.0*/
 abstract class AbstractVariableType implements VariableTypeInterface
 {
@@ -25,15 +21,15 @@ abstract class AbstractVariableType implements VariableTypeInterface
 
     abstract public function __toString(): string;
 
-    protected function isNullable(): bool
+    public function isNullable(): bool
     {
         return $this->nullable;
     }
 
-    abstract protected function validate(): void;
-
-    protected function getTypeName(): string
+    public function getTypeName(): string
     {
         return $this->__toString();
     }
+
+    abstract protected function validate(): void;
 }

--- a/src/VariableType/AbstractVariableType.php
+++ b/src/VariableType/AbstractVariableType.php
@@ -31,5 +31,27 @@ abstract class AbstractVariableType implements VariableTypeInterface
         return $this->__toString();
     }
 
+    public function equals(VariableTypeInterface $object): bool
+    {
+        if (static::class !== \get_class($object)) {
+            return false;
+        }
+        if ($this->isNullable() !== $object->isNullable()) {
+            return false;
+        }
+        return true;
+    }
+
+    public static function objectEquals(?VariableTypeInterface $a, ?VariableTypeInterface $b): bool
+    {
+        if ($a === $b) {
+            return true;
+        }
+        if ($a === null || $b === null) {
+            return false;
+        }
+        return $a->equals($b);
+    }
+
     abstract protected function validate(): void;
 }

--- a/src/VariableType/ArrayVariableType.php
+++ b/src/VariableType/ArrayVariableType.php
@@ -6,10 +6,6 @@ namespace ScrumWorks\PropertyReader\VariableType;
 
 use Exception;
 
-/**
- * @property-read VariableTypeInterface $itemType
- * @property-read VariableTypeInterface $keyType
- */
 final class ArrayVariableType extends AbstractVariableType
 {
     protected VariableTypeInterface $itemType;
@@ -29,12 +25,12 @@ final class ArrayVariableType extends AbstractVariableType
         return 'ARRAY';
     }
 
-    protected function getItemType(): VariableTypeInterface
+    public function getItemType(): VariableTypeInterface
     {
         return $this->itemType;
     }
 
-    protected function getKeyType(): ?VariableTypeInterface
+    public function getKeyType(): ?VariableTypeInterface
     {
         return $this->keyType;
     }
@@ -43,10 +39,10 @@ final class ArrayVariableType extends AbstractVariableType
     {
         $keysToCheck = [];
         if ($this->keyType instanceof UnionVariableType) {
-            if ($this->keyType->nullable) {
+            if ($this->keyType->isNullable()) {
                 throw new Exception("Key can't be nullable");
             }
-            $keysToCheck += $this->keyType->types;
+            $keysToCheck += $this->keyType->getTypes();
         } else {
             $keysToCheck[] = $this->keyType;
         }
@@ -56,10 +52,10 @@ final class ArrayVariableType extends AbstractVariableType
                 continue;
             }
             if (! ($key instanceof ScalarVariableType)) {
-                throw new Exception("Keys can be only scalar types, '{$key->typeName}' given");
+                throw new Exception(\sprintf("Keys can be only scalar types, '%s' given", $key->getTypeName()));
             }
-            if (! \in_array($key->type, [ScalarVariableType::TYPE_STRING, ScalarVariableType::TYPE_INTEGER])) {
-                throw new Exception("Key type can be only string or integer, '{$key->type}' given");
+            if (! \in_array($key->getType(), [ScalarVariableType::TYPE_STRING, ScalarVariableType::TYPE_INTEGER])) {
+                throw new Exception(\sprintf("Key type can be only string or integer, '%s' given", $key->getType()));
             }
             if ($key->nullable) {
                 throw new Exception("Key can't be nullable");

--- a/src/VariableType/ArrayVariableType.php
+++ b/src/VariableType/ArrayVariableType.php
@@ -35,6 +35,16 @@ final class ArrayVariableType extends AbstractVariableType
         return $this->keyType;
     }
 
+    public function equals(VariableTypeInterface $object): bool
+    {
+        if (! parent::equals($object)) {
+            return false;
+        }
+        /** @var ArrayVariableType $object */
+        return self::objectEquals($this->getKeyType(), $object->getKeyType())
+            && self::objectEquals($this->getItemType(), $object->getItemType());
+    }
+
     protected function validate(): void
     {
         $keysToCheck = [];

--- a/src/VariableType/ClassVariableType.php
+++ b/src/VariableType/ClassVariableType.php
@@ -27,6 +27,15 @@ final class ClassVariableType extends AbstractVariableType
         return $this->class;
     }
 
+    public function equals(VariableTypeInterface $object): bool
+    {
+        if (! parent::equals($object)) {
+            return false;
+        }
+        /** @var ClassVariableType $object */
+        return $this->getClass() === $object->getClass();
+    }
+
     protected function validate(): void
     {
         if (! \class_exists($this->class)) {

--- a/src/VariableType/ClassVariableType.php
+++ b/src/VariableType/ClassVariableType.php
@@ -6,9 +6,6 @@ namespace ScrumWorks\PropertyReader\VariableType;
 
 use Exception;
 
-/**
- * @property-read string $class FQN class name
- */
 final class ClassVariableType extends AbstractVariableType
 {
     protected string $class;
@@ -25,7 +22,7 @@ final class ClassVariableType extends AbstractVariableType
         return 'CLASS[' . $this->class . ']';
     }
 
-    protected function getClass(): string
+    public function getClass(): string
     {
         return $this->class;
     }

--- a/src/VariableType/ScalarVariableType.php
+++ b/src/VariableType/ScalarVariableType.php
@@ -35,6 +35,15 @@ final class ScalarVariableType extends AbstractVariableType
         return $this->type;
     }
 
+    public function equals(VariableTypeInterface $object): bool
+    {
+        if (! parent::equals($object)) {
+            return false;
+        }
+        /** @var ScalarVariableType $object */
+        return $this->getType() === $object->getType();
+    }
+
     protected function validate(): void
     {
         if (! \in_array($this->type, [self::TYPE_INTEGER, self::TYPE_FLOAT, self::TYPE_BOOLEAN, self::TYPE_STRING])) {

--- a/src/VariableType/ScalarVariableType.php
+++ b/src/VariableType/ScalarVariableType.php
@@ -6,9 +6,6 @@ namespace ScrumWorks\PropertyReader\VariableType;
 
 use Exception;
 
-/**
- * @property-read string $type
- */
 final class ScalarVariableType extends AbstractVariableType
 {
     public const TYPE_INTEGER = 'INTEGER';
@@ -33,7 +30,7 @@ final class ScalarVariableType extends AbstractVariableType
         return 'SCALAR[' . $this->type . ']';
     }
 
-    protected function getType(): string
+    public function getType(): string
     {
         return $this->type;
     }

--- a/src/VariableType/UnionVariableType.php
+++ b/src/VariableType/UnionVariableType.php
@@ -33,6 +33,15 @@ final class UnionVariableType extends AbstractVariableType
         return $this->types;
     }
 
+    public function equals(VariableTypeInterface $object): bool
+    {
+        if (! parent::equals($object)) {
+            return false;
+        }
+        /** @var UnionVariableType $object */
+        return $this->isSubset($this, $object) && $this->isSubset($this, $object);
+    }
+
     protected function validate(): void
     {
         if (\count($this->types) < 2) {
@@ -47,5 +56,24 @@ final class UnionVariableType extends AbstractVariableType
                 ));
             }
         }
+    }
+
+    /**
+     * Is union type $a subset of $b?
+     * Actually O(n^2) in worst case :/
+     */
+    private function isSubset(self $a, self $b): bool
+    {
+        foreach ($a->getTypes() as $aType) {
+            foreach ($b->getTypes() as $bType) {
+                if ($aType->equals($bType)) {
+                    // found, we can move to next element
+                    continue 2;
+                }
+            }
+            // not found, it can't be subset
+            return false;
+        }
+        return true;
     }
 }

--- a/src/VariableType/UnionVariableType.php
+++ b/src/VariableType/UnionVariableType.php
@@ -6,9 +6,6 @@ namespace ScrumWorks\PropertyReader\VariableType;
 
 use Exception;
 
-/**
- * @property-read VariableTypeInterface[] $types
- */
 final class UnionVariableType extends AbstractVariableType
 {
     protected array $types;
@@ -31,7 +28,7 @@ final class UnionVariableType extends AbstractVariableType
     /**
      * @return VariableTypeInterface[]
      */
-    protected function getTypes(): array
+    public function getTypes(): array
     {
         return $this->types;
     }

--- a/src/VariableType/VariableTypeInterface.php
+++ b/src/VariableType/VariableTypeInterface.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace ScrumWorks\PropertyReader\VariableType;
 
-/**
- * @property-read string $typeName
- * @property-read bool $nullable
- */
 interface VariableTypeInterface
 {
+    public function isNullable(): bool;
+
+    public function getTypeName(): string;
 }

--- a/src/VariableType/VariableTypeInterface.php
+++ b/src/VariableType/VariableTypeInterface.php
@@ -9,4 +9,6 @@ interface VariableTypeInterface
     public function isNullable(): bool;
 
     public function getTypeName(): string;
+
+    public function equals(self $object): bool;
 }

--- a/src/VariableTypeUnifyService.php
+++ b/src/VariableTypeUnifyService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ScrumWorks\PropertyReader;
 
 use Exception;
+use ScrumWorks\PropertyReader\VariableType\AbstractVariableType;
 use ScrumWorks\PropertyReader\VariableType\ArrayVariableType;
 use ScrumWorks\PropertyReader\VariableType\ClassVariableType;
 use ScrumWorks\PropertyReader\VariableType\MixedVariableType;
@@ -14,42 +15,6 @@ use ScrumWorks\PropertyReader\VariableType\VariableTypeInterface;
 
 final class VariableTypeUnifyService implements VariableTypeUnifyServiceInterface
 {
-    /**
-     * @TODO maybe move directly to VariableTypeInterface?
-     */
-    public function same(?VariableTypeInterface $a, ?VariableTypeInterface $b): bool
-    {
-        if ($a === $b) {
-            return true;
-        }
-        if ($a === null || $b === null) {
-            return false;
-        }
-        if (! ($a instanceof $b)) {
-            return false;
-        }
-        if ($a->isNullable() !== $b->isNullable()) {
-            return false;
-        }
-        if ($a instanceof MixedVariableType) {
-            return true;
-        } elseif ($a instanceof ScalarVariableType) {
-            /** @var ScalarVariableType $b */
-            return $a->getType() === $b->getType();
-        } elseif ($a instanceof ArrayVariableType) {
-            /** @var ArrayVariableType $b */
-            return $this->same($a->getKeyType(), $b->getKeyType())
-                && $this->same($a->getItemType(), $b->getItemType());
-        } elseif ($a instanceof ClassVariableType) {
-            /** @var ClassVariableType $b */
-            return $a->getClass() === $b->getClass();
-        } elseif ($a instanceof UnionVariableType) {
-            /** @var UnionVariableType $b */
-            return $this->isSubset($a, $b) && $this->isSubset($b, $a);
-        }
-        return false;
-    }
-
     public function unify(?VariableTypeInterface $a, ?VariableTypeInterface $b): VariableTypeInterface
     {
         if ($a === null && $b === null) {
@@ -96,25 +61,6 @@ final class VariableTypeUnifyService implements VariableTypeUnifyServiceInterfac
         throw new Exception(\sprintf('Uknown %s for merging', VariableTypeInterface::class));
     }
 
-    /**
-     * Is union type $a subset of $b?
-     * Actually O(n^2) in worst case :/
-     */
-    private function isSubset(UnionVariableType $a, UnionVariableType $b): bool
-    {
-        foreach ($a->getTypes() as $aType) {
-            foreach ($b->getTypes() as $bType) {
-                if ($this->same($aType, $bType)) {
-                    // found, we can move to next element
-                    continue 2;
-                }
-            }
-            // not found, it can't be subset
-            return false;
-        }
-        return true;
-    }
-
     private function unifyMixed(MixedVariableType $a, MixedVariableType $b): VariableTypeInterface
     {
         return clone $a;
@@ -139,7 +85,7 @@ final class VariableTypeUnifyService implements VariableTypeUnifyServiceInterfac
             return clone $a;
         }
 
-        if (! $this->same($a->getKeyType(), $b->getKeyType())) {
+        if (! AbstractVariableType::objectEquals($a->getKeyType(), $b->getKeyType())) {
             throw new Exception(\sprintf('Array must have key type'));
         }
 
@@ -161,7 +107,7 @@ final class VariableTypeUnifyService implements VariableTypeUnifyServiceInterfac
 
     private function unifyUnion(UnionVariableType $a, UnionVariableType $b): VariableTypeInterface
     {
-        if ($this->same($a, $b)) {
+        if ($a->equals($b)) {
             return clone $a;
         }
 

--- a/tests/PropertyReaderTest.php
+++ b/tests/PropertyReaderTest.php
@@ -123,36 +123,36 @@ class PropertyReaderTest extends TestCase
         $property = $reflection->getProperty('notNullable');
         $this->assertEquals(
             false,
-            $this->readFromPropertyType($property)->nullable
+            $this->readFromPropertyType($property)->isNullable()
         );
         $this->assertEquals(
             false,
-            $this->readFromPhpDoc($property)->nullable
+            $this->readFromPhpDoc($property)->isNullable()
         );
 
         // ?var syntax
         $property = $reflection->getProperty('nullable');
         $this->assertEquals(
             true,
-            $this->readFromPropertyType($property)->nullable
+            $this->readFromPropertyType($property)->isNullable()
         );
         $this->assertEquals(
             true,
-            $this->readFromPhpDoc($property)->nullable
+            $this->readFromPhpDoc($property)->isNullable()
         );
 
         // var|null syntax
         $property = $reflection->getProperty('nullableSecondVariant');
         $this->assertEquals(
             true,
-            $this->readFromPhpDoc($property)->nullable
+            $this->readFromPhpDoc($property)->isNullable()
         );
 
         // multiple nullable are ignored
         $property = $reflection->getProperty('multipleNullable');
         $this->assertEquals(
             true,
-            $this->readFromPhpDoc($property)->nullable
+            $this->readFromPhpDoc($property)->isNullable()
         );
 
         // property with only nullable definition

--- a/tests/VariableType/AbstractVariableTypeTest.php
+++ b/tests/VariableType/AbstractVariableTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace ScrumWorks\PropertyReader\Tests\VariableType;
+
+use ScrumWorks\PropertyReader\Tests\VariableTypeCreatingTrait;
+use ScrumWorks\PropertyReader\VariableType\AbstractVariableType;
+use PHPUnit\Framework\TestCase;
+
+class AbstractVariableTypeTest extends TestCase
+{
+    use VariableTypeCreatingTrait;
+
+    public function testObjectEquals(): void
+    {
+        // `equals` is reflexive
+        $this->assertTrue($this->variableTypeEquals(null, null));
+
+        // `equals` is symmetric
+        $this->assertFalse($this->variableTypeEquals(null, $this->createInteger(true)));
+        $this->assertFalse($this->variableTypeEquals($this->createInteger(true),null));
+
+        // nullable must have same values
+        $this->assertFalse($this->variableTypeEquals($this->createInteger(true), $this->createInteger(false)));
+
+        // objects must have same type
+        $this->assertFalse(
+            $this->variableTypeEquals(
+                $this->createInteger(true),
+                $this->createMixed()
+            )
+        );
+    }
+}

--- a/tests/VariableType/ArrayVariableTypeTest.php
+++ b/tests/VariableType/ArrayVariableTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace ScrumWorks\PropertyReader\Tests\VariableType;
 
+use ScrumWorks\PropertyReader\Tests\VariableTypeCreatingTrait;
 use ScrumWorks\PropertyReader\VariableType\ArrayVariableType;
 use ScrumWorks\PropertyReader\VariableType\MixedVariableType;
 use ScrumWorks\PropertyReader\VariableType\ScalarVariableType;
@@ -12,6 +13,8 @@ use PHPUnit\Framework\TestCase;
 
 class ArrayVariableTypeTest extends TestCase
 {
+    use VariableTypeCreatingTrait;
+
     public function testValidIntStringUnionKey(): void
     {
         $arrayVariableType = new ArrayVariableType(
@@ -79,6 +82,28 @@ class ArrayVariableTypeTest extends TestCase
                 new MixedVariableType(),
             ], false),
             false
+        );
+    }
+
+    public function testEquals(): void
+    {
+        $this->assertTrue(
+            $this->variableTypeEquals(
+                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
+                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
+            )
+        );
+        $this->assertFalse(
+            $this->variableTypeEquals(
+                new ArrayVariableType($this->createString(true), $this->createString(false), false),
+                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
+            )
+        );
+        $this->assertFalse(
+            $this->variableTypeEquals(
+                new ArrayVariableType($this->createInteger(true), null, false),
+                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
+            )
         );
     }
 }

--- a/tests/VariableType/ClassVariableTypeTest.php
+++ b/tests/VariableType/ClassVariableTypeTest.php
@@ -12,7 +12,7 @@ class ClassVariableTypeTest extends TestCase
     public function testValidClass(): void
     {
         $classVariableType = new ClassVariableType(ClassVariableTypeTest::class, true);
-        $this->assertEquals(ClassVariableTypeTest::class, $classVariableType->class);
+        $this->assertEquals(ClassVariableTypeTest::class, $classVariableType->getClass());
     }
 
     public function testInvalidClass(): void

--- a/tests/VariableType/ClassVariableTypeTest.php
+++ b/tests/VariableType/ClassVariableTypeTest.php
@@ -4,11 +4,16 @@ declare(strict_types = 1);
 
 namespace ScrumWorks\PropertyReader\Tests\VariableType;
 
+use ScrumWorks\PropertyReader\Tests\VariableTypeCreatingTrait;
+use ScrumWorks\PropertyReader\VariableType\ArrayVariableType;
 use ScrumWorks\PropertyReader\VariableType\ClassVariableType;
 use PHPUnit\Framework\TestCase;
+use ScrumWorks\PropertyReader\VariableType\MixedVariableType;
 
 class ClassVariableTypeTest extends TestCase
 {
+    use VariableTypeCreatingTrait;
+
     public function testValidClass(): void
     {
         $classVariableType = new ClassVariableType(ClassVariableTypeTest::class, true);
@@ -20,5 +25,11 @@ class ClassVariableTypeTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectErrorMessage("Unknown class 'some-not-existing-class' given");
         new ClassVariableType('some-not-existing-class', true);
+    }
+
+    public function testEquals(): void
+    {
+        $this->assertTrue($this->variableTypeEquals(new ClassVariableType(ArrayVariableType::class, false), new ClassVariableType(ArrayVariableType::class, false)));
+        $this->assertFalse($this->variableTypeEquals(new ClassVariableType(ArrayVariableType::class, false), new ClassVariableType(MixedVariableType::class, false)));
     }
 }

--- a/tests/VariableType/MixedVariableTypeTest.php
+++ b/tests/VariableType/MixedVariableTypeTest.php
@@ -12,6 +12,6 @@ class MixedVariableTypeTest extends TestCase
     public function testIsNullable(): void
     {
         $mixedVariableType = new MixedVariableType();
-        $this->assertTrue($mixedVariableType->nullable);
+        $this->assertTrue($mixedVariableType->isNullable());
     }
 }

--- a/tests/VariableType/ScalarVariableTypeTest.php
+++ b/tests/VariableType/ScalarVariableTypeTest.php
@@ -4,15 +4,24 @@ declare(strict_types = 1);
 
 namespace ScrumWorks\PropertyReader\Tests\VariableType;
 
+use ScrumWorks\PropertyReader\Tests\VariableTypeCreatingTrait;
 use ScrumWorks\PropertyReader\VariableType\ScalarVariableType;
 use PHPUnit\Framework\TestCase;
 
 class ScalarVariableTypeTest extends TestCase
 {
+    use VariableTypeCreatingTrait;
+
     public function testBadParameterType(): void
     {
         $this->expectException(\Exception::class);
         $this->expectErrorMessage("Unknown 'some-not-exists-constant' scalar type given");
         new ScalarVariableType('some-not-exists-constant', false);
+    }
+
+    public function testEquals(): void
+    {
+        $this->assertTrue($this->variableTypeEquals($this->createInteger(true), $this->createInteger(true)));
+        $this->assertFalse($this->variableTypeEquals($this->createInteger(true), $this->createString(true)));
     }
 }

--- a/tests/VariableType/UnionVariableTypeTest.php
+++ b/tests/VariableType/UnionVariableTypeTest.php
@@ -4,12 +4,16 @@ declare(strict_types = 1);
 
 namespace ScrumWorks\PropertyReader\Tests\VariableType;
 
+use ScrumWorks\PropertyReader\Tests\VariableTypeCreatingTrait;
+use ScrumWorks\PropertyReader\VariableType\ArrayVariableType;
 use ScrumWorks\PropertyReader\VariableType\MixedVariableType;
 use ScrumWorks\PropertyReader\VariableType\UnionVariableType;
 use PHPUnit\Framework\TestCase;
 
 class UnionVariableTypeTest extends TestCase
 {
+    use VariableTypeCreatingTrait;
+
     public function testMinimumInputTypes(): void
     {
         $this->expectException(\Exception::class);
@@ -23,5 +27,49 @@ class UnionVariableTypeTest extends TestCase
         $this->expectErrorMessage("Given type 'integer' doesn't implements ScrumWorks\PropertyReader\VariableType\VariableTypeInterface");
         // @phpstan-ignore-next-line
         new UnionVariableType([1, new MixedVariableType()], false);
+    }
+
+    public function testEquals(): void
+    {
+        $this->assertTrue(
+            $this->variableTypeEquals(
+                new UnionVariableType([
+                    $this->createInteger(true),
+                    $this->createString(false),
+                    new ArrayVariableType($this->createString(false), null, false),
+                ], true),
+                new UnionVariableType([
+                    new ArrayVariableType($this->createString(false), null, false),
+                    $this->createString(false),
+                    $this->createInteger(true),
+                ], true)
+            )
+        );
+        $this->assertTrue(
+            $this->variableTypeEquals(
+                new UnionVariableType([
+                    $this->createInteger(true),
+                    $this->createInteger(true),
+                    $this->createInteger(false),
+                ], true),
+                new UnionVariableType([
+                    $this->createInteger(false),
+                    $this->createInteger(true),
+                ], true)
+            )
+        );
+        $this->assertFalse(
+            $this->variableTypeEquals(
+                new UnionVariableType([
+                    $this->createString(true),
+                    $this->createInteger(true),
+                    $this->createInteger(false),
+                ], true),
+                new UnionVariableType([
+                    $this->createInteger(true),
+                    $this->createInteger(false),
+                ], true)
+            )
+        );
     }
 }

--- a/tests/VariableTypeCreatingTrait.php
+++ b/tests/VariableTypeCreatingTrait.php
@@ -4,8 +4,10 @@ declare(strict_types = 1);
 
 namespace ScrumWorks\PropertyReader\Tests;
 
+use ScrumWorks\PropertyReader\VariableType\AbstractVariableType;
 use ScrumWorks\PropertyReader\VariableType\MixedVariableType;
 use ScrumWorks\PropertyReader\VariableType\ScalarVariableType;
+use ScrumWorks\PropertyReader\VariableType\VariableTypeInterface;
 
 trait VariableTypeCreatingTrait
 {
@@ -32,5 +34,10 @@ trait VariableTypeCreatingTrait
     private function createString(bool $nullable): ScalarVariableType
     {
         return new ScalarVariableType(ScalarVariableType::TYPE_STRING, $nullable);
+    }
+
+    private function variableTypeEquals(?VariableTypeInterface $a, ?VariableTypeInterface $b): bool
+    {
+        return AbstractVariableType::objectEquals($a, $b);
     }
 }

--- a/tests/VariableTypeUnifyServiceTest.php
+++ b/tests/VariableTypeUnifyServiceTest.php
@@ -23,89 +23,6 @@ class VariableTypeUnifyServiceTest extends TestCase
         $this->variableTypeUnifyService = new VariableTypeUnifyService();
     }
 
-    public function testSame(): void
-    {
-        // `same` is reflexive
-        $this->assertTrue($this->same(null, null));
-
-        // `same` is symmetric
-        $this->assertFalse($this->same(null, $this->createInteger(true)));
-        $this->assertFalse($this->same($this->createInteger(true),null));
-
-        // nullable must have same values
-        $this->assertFalse($this->same($this->createInteger(true), $this->createInteger(false)));
-
-        // scalar values are same when have same types
-        $this->assertTrue($this->same($this->createInteger(true), $this->createInteger(true)));
-        $this->assertFalse($this->same($this->createInteger(true), $this->createString(true)));
-
-        // array must have same key and item type
-        $this->assertTrue(
-            $this->same(
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
-            )
-        );
-        $this->assertFalse(
-            $this->same(
-                new ArrayVariableType($this->createString(true), $this->createString(false), false),
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
-            )
-        );
-        $this->assertFalse(
-            $this->same(
-                new ArrayVariableType($this->createInteger(true), null, false),
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
-            )
-        );
-
-        // objects must have same type
-        $this->assertTrue($this->same(new ClassVariableType(ArrayVariableType::class, false), new ClassVariableType(ArrayVariableType::class, false)));
-        $this->assertFalse($this->same(new ClassVariableType(ArrayVariableType::class, false), new ClassVariableType(MixedVariableType::class, false)));
-
-        // union types must be equivalent (order doesn't matters)
-        $this->assertTrue(
-            $this->same(
-                new UnionVariableType([
-                    $this->createInteger(true),
-                    $this->createString(false),
-                    new ArrayVariableType($this->createString(false), null, false),
-                ], true),
-                new UnionVariableType([
-                    new ArrayVariableType($this->createString(false), null, false),
-                    $this->createString(false),
-                    $this->createInteger(true),
-                ], true)
-            )
-        );
-        $this->assertTrue(
-            $this->same(
-                new UnionVariableType([
-                    $this->createInteger(true),
-                    $this->createInteger(true),
-                    $this->createInteger(false),
-                ], true),
-                new UnionVariableType([
-                    $this->createInteger(false),
-                    $this->createInteger(true),
-                ], true)
-            )
-        );
-        $this->assertFalse(
-            $this->same(
-                new UnionVariableType([
-                    $this->createString(true),
-                    $this->createInteger(true),
-                    $this->createInteger(false),
-                ], true),
-                new UnionVariableType([
-                    $this->createInteger(true),
-                    $this->createInteger(false),
-                ], true)
-            )
-        );
-    }
-
     public function testUnify(): void
     {
         // `unify` is reflexive, only difference is that unify(null, null) === MixedVariableType
@@ -207,11 +124,6 @@ class VariableTypeUnifyServiceTest extends TestCase
                 $this->createInteger(false),
             ], true)
         );
-    }
-
-    private function same(?VariableTypeInterface $a, ?VariableTypeInterface $b): bool
-    {
-        return $this->variableTypeUnifyService->same($a, $b);
     }
 
     private function unify(?VariableTypeInterface $a, ?VariableTypeInterface $b): VariableTypeInterface


### PR DESCRIPTION
### What's this PR do?
- move `equals` method to `VariableType`
- remove usage of `@property-read`