### PR TITLE
Fix for arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,97 @@
 composer require scrumworks/property-reader
 ```
 
-## Example
+## Documentation
+
+Class property can be translated to these variants:
+
+### null
+
+`null` is returned for properties without any information.
+
+It's generally `mixed` type, but it's acting differently f.e. in array types.
+
+```php
+public $var;
+```
+### MixedVariableType
+
+It's returned for variables with `mixed` directly information.
+
+```php
+/**
+ * @var mixed
+ */
+public $var;
+```
+
+### ScalarVariableType
+
+Supports this basic scalar types:
+  - `int`, `integer`
+  - `float`
+  - `bool`, `boolean`
+  - `string`
+
+```php
+/**
+ * @var integer
+ */
+public int $var;
+```
+### ArrayVariableType
+
+Arrays are considered to be seqential array or hashmap.
+
+Arrays are translated in this way: (we use definition `array<key, type>`)
+- generic `array` has type `array<null, null>`
+- seqential `int[]` has type `array<null, int>`
+- hashmap `array<string, string>` has type `array<string, string>`
+
+In general - `null` in `key` is proposing seqential array, other types (only `integer` and  `string` are supported) are
+propose hashmap. Only difference is `key == value == null`, then it's
+generic array.
+
+**Warning** - `mixed[]` has different type than `array`
+
+We also support nested arrays like `int[][]` or `array<string, string>[]`
+
+```php
+/**
+ * @var int[]
+ */
+public array $var;
+```
+
+### ClassVariableType
+
+```php
+/**
+ * @var SomeClass
+ */
+public SomeClass $var;
+```
+
+### UnionVariableType
+
+```php
+/**
+ * @var int|string
+ */
+public $var;
+```
+
+### Nullablity of types
+
+Every type can by set to be nullable in this ways:
+- `?int`
+- `int|null`
+
+Types `null` and `MixedVariableType` are nullable by default.
+
+**Warning** - `?int|string` isn't `(?int)|string` but `int|string|null`
+
+## Example usage
 
 ```php
 <?php

--- a/src/PropertyReader.php
+++ b/src/PropertyReader.php
@@ -126,16 +126,16 @@ final class PropertyReader implements PropertyReaderInterface
     private function tryIsArray(string $type, bool $nullable, ReflectionProperty $property): ?VariableTypeInterface
     {
         if ($type === 'array') {
-            return new ArrayVariableType(new MixedVariableType(), null, $nullable);
+            return new ArrayVariableType(null, null, $nullable);
         }
         if (\substr($type, -2) === '[]') {
             $itemType = $this->parseType(\substr($type, 0, -2), $property);
-            return new ArrayVariableType($itemType, null, $nullable);
+            return new ArrayVariableType(null, $itemType, $nullable);
         }
         if ($match = Strings::match($type, '~^array<((?P<key>[^,]+)\s*,\s*)?(?P<type>.+)>$~')) {
             $itemType = $this->parseType($match['type'], $property);
             $keyType = $match['key'] ? $this->parseType($match['key'], $property) : null;
-            return new ArrayVariableType($itemType, $keyType, $nullable);
+            return new ArrayVariableType($keyType, $itemType, $nullable);
         }
 
         return null;

--- a/src/PropertyWriter.php
+++ b/src/PropertyWriter.php
@@ -32,7 +32,7 @@ final class PropertyWriter
                 return 'array';
             }
             if ($variableType->getKeyType() === null) {
-                if ($variableType->getItemType() instanceof MixedVariableType) {
+                if ($variableType->getItemType() === null) {
                     return ($variableType->isNullable() ? '?' : '') . 'array';
                 }
                 return ($variableType->isNullable() ? '?' : '') . $this->variableTypeToString(

--- a/src/VariableType/ArrayVariableType.php
+++ b/src/VariableType/ArrayVariableType.php
@@ -8,14 +8,14 @@ use Exception;
 
 final class ArrayVariableType extends AbstractVariableType
 {
-    protected VariableTypeInterface $itemType;
-
     protected ?VariableTypeInterface $keyType;
 
-    public function __construct(VariableTypeInterface $itemType, ?VariableTypeInterface $keyType, bool $nullable)
+    protected ?VariableTypeInterface $itemType;
+
+    public function __construct(?VariableTypeInterface $keyType, ?VariableTypeInterface $itemType, bool $nullable)
     {
-        $this->itemType = $itemType;
         $this->keyType = $keyType;
+        $this->itemType = $itemType;
 
         parent::__construct($nullable);
     }
@@ -25,14 +25,14 @@ final class ArrayVariableType extends AbstractVariableType
         return 'ARRAY';
     }
 
-    public function getItemType(): VariableTypeInterface
-    {
-        return $this->itemType;
-    }
-
     public function getKeyType(): ?VariableTypeInterface
     {
         return $this->keyType;
+    }
+
+    public function getItemType(): ?VariableTypeInterface
+    {
+        return $this->itemType;
     }
 
     public function equals(VariableTypeInterface $object): bool

--- a/tests/PropertyReaderTest.php
+++ b/tests/PropertyReaderTest.php
@@ -306,7 +306,7 @@ class PropertyReaderTest extends TestCase
         $property = $reflection->getProperty('array');
         $this->assertEquals(
             new ArrayVariableType(
-                $this->createMixed(),
+                null,
                 null,
                 false
             ),
@@ -314,8 +314,8 @@ class PropertyReaderTest extends TestCase
         );
         $this->assertEquals(
             new ArrayVariableType(
-                $this->createInteger(false),
                 null,
+                $this->createInteger(false),
                 false
             ),
             $this->readFromPhpDoc($property)
@@ -325,8 +325,8 @@ class PropertyReaderTest extends TestCase
         $property = $reflection->getProperty('arrayAlternative');
         $this->assertEquals(
             new ArrayVariableType(
-                $this->createInteger(false),
                 null,
+                $this->createInteger(false),
                 false
             ),
             $this->readFromPhpDoc($property)
@@ -336,7 +336,7 @@ class PropertyReaderTest extends TestCase
         $property = $reflection->getProperty('generalArray');
         $this->assertEquals(
             new ArrayVariableType(
-                $this->createMixed(),
+                null,
                 null,
                 false
             ),
@@ -347,12 +347,12 @@ class PropertyReaderTest extends TestCase
         $property = $reflection->getProperty('nestedArray');
         $this->assertEquals(
             new ArrayVariableType(
+                null,
                 new ArrayVariableType(
-                    $this->createInteger(false),
                     null,
+                    $this->createInteger(false),
                     false
                 ),
-                null,
                 false
             ),
             $this->readFromPhpDoc($property)
@@ -373,12 +373,12 @@ class PropertyReaderTest extends TestCase
         $property = $reflection->getProperty('nestedHashmap');
         $this->assertEquals(
             new ArrayVariableType(
+                $this->createString(false),
                 new ArrayVariableType(
-                    $this->createString(false),
                     $this->createInteger(false),
+                    $this->createString(false),
                     false
                 ),
-                $this->createString(false),
                 false
             ),
             $this->readFromPhpDoc($property)
@@ -388,19 +388,19 @@ class PropertyReaderTest extends TestCase
         $property = $reflection->getProperty('complicatedArray');
         $this->assertEquals(
             new ArrayVariableType(
-                new ArrayVariableType(
-                    new ArrayVariableType(
-                        $this->createInteger(false),
-                        null,
-                        false
-                    ),
-                    null,
-                    true
-                ),
                 new UnionVariableType([
                     $this->createInteger(false),
                     $this->createString(false),
                 ], false),
+                new ArrayVariableType(
+                    null,
+                    new ArrayVariableType(
+                        null,
+                        $this->createInteger(false),
+                        false
+                    ),
+                    true
+                ),
                 false
             ),
             $this->readFromPhpDoc($property)

--- a/tests/VariableType/ArrayVariableTypeTest.php
+++ b/tests/VariableType/ArrayVariableTypeTest.php
@@ -18,11 +18,11 @@ class ArrayVariableTypeTest extends TestCase
     public function testValidIntStringUnionKey(): void
     {
         $arrayVariableType = new ArrayVariableType(
-            new MixedVariableType(),
             new UnionVariableType([
                 new ScalarVariableType(ScalarVariableType::TYPE_STRING, false),
                 new ScalarVariableType(ScalarVariableType::TYPE_INTEGER, false),
             ], false),
+            new MixedVariableType(),
             true
         );
         $this->assertNotNull($arrayVariableType); // TODO maybe another assertation?
@@ -40,8 +40,8 @@ class ArrayVariableTypeTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectErrorMessage("Key type can be only string or integer, 'BOOLEAN' given");
         new ArrayVariableType(
-            new MixedVariableType(),
             new ScalarVariableType(ScalarVariableType::TYPE_BOOLEAN, false),
+            new MixedVariableType(),
             true
         );
     }
@@ -51,8 +51,8 @@ class ArrayVariableTypeTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectErrorMessage("Key can't be nullable");
         new ArrayVariableType(
-            new MixedVariableType(),
             new ScalarVariableType(ScalarVariableType::TYPE_STRING, true),
+            new MixedVariableType(),
             true
         );
     }
@@ -62,11 +62,11 @@ class ArrayVariableTypeTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectErrorMessage("Key can't be nullable");
         new ArrayVariableType(
-            new MixedVariableType(),
             new UnionVariableType([
                 new ScalarVariableType(ScalarVariableType::TYPE_STRING, false),
                 new ScalarVariableType(ScalarVariableType::TYPE_INTEGER, false),
             ], true),
+            new MixedVariableType(),
             true
         );
     }
@@ -76,11 +76,11 @@ class ArrayVariableTypeTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectErrorMessage("Keys can be only scalar types, 'MIXED' given");
         new ArrayVariableType(
-            new MixedVariableType(),
             new UnionVariableType([
                 new ScalarVariableType(ScalarVariableType::TYPE_STRING, false),
                 new MixedVariableType(),
             ], false),
+            new MixedVariableType(),
             false
         );
     }
@@ -89,20 +89,20 @@ class ArrayVariableTypeTest extends TestCase
     {
         $this->assertTrue(
             $this->variableTypeEquals(
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
+                new ArrayVariableType($this->createString(false), $this->createInteger(true), false),
+                new ArrayVariableType($this->createString(false), $this->createInteger(true), false),
             )
         );
         $this->assertFalse(
             $this->variableTypeEquals(
-                new ArrayVariableType($this->createString(true), $this->createString(false), false),
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
+                new ArrayVariableType($this->createString(false), $this->createString(true), false),
+                new ArrayVariableType($this->createString(false), $this->createInteger(true), false),
             )
         );
         $this->assertFalse(
             $this->variableTypeEquals(
-                new ArrayVariableType($this->createInteger(true), null, false),
-                new ArrayVariableType($this->createInteger(true), $this->createString(false), false),
+                new ArrayVariableType(null, $this->createInteger(true), false),
+                new ArrayVariableType($this->createString(false), $this->createInteger(true), false),
             )
         );
     }

--- a/tests/VariableType/UnionVariableTypeTest.php
+++ b/tests/VariableType/UnionVariableTypeTest.php
@@ -36,10 +36,10 @@ class UnionVariableTypeTest extends TestCase
                 new UnionVariableType([
                     $this->createInteger(true),
                     $this->createString(false),
-                    new ArrayVariableType($this->createString(false), null, false),
+                    new ArrayVariableType(null, $this->createString(false), false),
                 ], true),
                 new UnionVariableType([
-                    new ArrayVariableType($this->createString(false), null, false),
+                    new ArrayVariableType(null, $this->createString(false), false),
                     $this->createString(false),
                     $this->createInteger(true),
                 ], true)

--- a/tests/VariableTypeUnifyServiceTest.php
+++ b/tests/VariableTypeUnifyServiceTest.php
@@ -76,17 +76,17 @@ class VariableTypeUnifyServiceTest extends TestCase
         // array type
         // array + int[] = int[]
         $this->assertEquals(
-            new ArrayVariableType($this->createInteger(false), null, false), // int[]
+            new ArrayVariableType(null, $this->createInteger(false), false), // int[]
             $this->unify(
-                new ArrayVariableType($this->createMixed(), null, false), // array
-                new ArrayVariableType($this->createInteger(false), null, false), // int[]
+                new ArrayVariableType(null, $this->createMixed(), false), // array
+                new ArrayVariableType(null, $this->createInteger(false), false), // int[]
             )
         );
         // array<string, string> + string[] causes exception
         $this->expectException(\Exception::class);
         $this->unify(
             new ArrayVariableType($this->createString(false), $this->createString(false), false), // array<string, string>
-            new ArrayVariableType($this->createString(false), null, false), // string[]
+            new ArrayVariableType(null, $this->createString(false), false), // string[]
         );
 
         // classes must have same class type


### PR DESCRIPTION
### What's this PR do?
- add support for `null` in `itemType` for arrays
- **BC change**: `key` and `itemType` in different order for arrays (compatible with writing `array<key, type>`)